### PR TITLE
Integrate ansible kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
+.kitchen
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,22 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: ansible_playbook
+  roles_path: roles
+  ansible_verbose: true
+  ansible_verbosity: 2
+  require_ruby_for_busser: false
+  require_chef_for_busser: true
+  hosts: all
+  roles_path: ../
+
+platforms:
+  - name: centos-7.2
+    driver_config:
+      box: wittman/centos-7.2-ansible
+  - name: ubuntu-14.04
+
+suites:
+  - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "test-kitchen"
+gem "kitchen-ansible"
+gem "kitchen-vagrant"
+
+group :integration do
+  gem 'serverspec'
+  gem 'specinfra'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,71 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    highline (1.7.8)
+    kitchen-ansible (0.40.1)
+      librarian-ansible
+      test-kitchen (~> 1.4)
+    kitchen-vagrant (0.19.0)
+      test-kitchen (~> 1.4)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-ansible (3.0.0)
+      faraday
+      librarian (~> 0.1.0)
+    mixlib-install (0.7.1)
+    mixlib-shellout (2.2.6)
+    multi_json (1.11.2)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.1.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    safe_yaml (1.0.4)
+    serverspec (2.18.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.35)
+    specinfra (2.36.0)
+      net-scp
+      net-ssh
+    test-kitchen (1.6.0)
+      mixlib-install (~> 0.7)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 4.0)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kitchen-ansible
+  kitchen-vagrant
+  serverspec
+  specinfra
+  test-kitchen
+
+BUNDLED WITH
+   1.11.2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,12 @@
 ---
 - name: Restart Docker
-  service:
-    name: 'docker'
-    state: restarted
+  service: name=docker state=restarted
+
+- name: Start Docker
+  service: name=docker state=started
+
+- name: Reload Docker
+  service: name=docker state=reloaded
+
+- name: Stop Docker
+  service: name=docker state=stopped

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -30,30 +30,3 @@
   set_fact:
     docker_opts: "{{ docker_opts }} -H tcp://{{ docker_tls_bind }}:{{ docker_tls_port }} --tlsverify --tlscacert={{ docker_tls_basepath }}/ca.crt --tlscert={{ docker_tls_basepath }}/server.crt --tlskey={{ docker_tls_basepath }}/server.key"
   when: docker_tls_enable == True
-
-- name: Create Docker upstart default config file
-  template:
-    src: 'docker-defaults.j2'
-    dest: '/etc/default/docker'
-  when: ansible_service_mgr == "upstart"
-  notify:
-    - Restart Docker
-
-- name: Ensure docker systemd drop-in directory exists
-  file:
-    path: '/etc/systemd/system/docker.service.d'
-    state: directory
-  when: ansible_service_mgr == "systemd"
-
-- name: Create Docker systemd drop-in file
-  template:
-    src: 'docker-systemd-service.j2'
-    dest: '/etc/systemd/system/docker.service.d/override.conf'
-  when: ansible_service_mgr == "systemd"
-  register: dropinfile
-  notify:
-    - Restart Docker
-
-- name: Reload systemd
-  command: 'systemctl daemon-reload'
-  when: ansible_service_mgr == "systemd" and dropinfile.changed

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -24,3 +24,10 @@
   apt:
     name: 'docker-engine'
     state: present
+
+- name: Create Docker upstart default config file
+  template:
+    src: 'docker-defaults.j2'
+    dest: '/etc/default/docker'
+  notify:
+    - Restart Docker

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -15,3 +15,19 @@
   yum:
     name: 'docker-engine'
     state: present
+
+- name: Ensure docker systemd drop-in directory exists
+  file:
+    path: '/etc/systemd/system/docker.service.d'
+    state: directory
+
+- name: Create Docker systemd drop-in file
+  template:
+    src: 'docker-systemd-service.j2'
+    dest: '/etc/systemd/system/docker.service.d/override.conf'
+  register: dropinfile
+  notify:
+    - Restart Docker
+
+- name: Reload systemd
+  command: 'systemctl daemon-reload'

--- a/test/integration/default/bats/default.bats
+++ b/test/integration/default/bats/default.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "Checking for docker executable" {
+  command -v docker
+}

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - ansible-role-docker


### PR DESCRIPTION
@jgeusebroek 

Hi, thank you for role, especially for CentOS support.

Adding few missing features:
 - handlers
 - ansible kitchen integration
 - tests

```bash
bundle exec kitchen verify
-----> Starting Kitchen (v1.6.0)
-----> Verifying <default-centos-72>...
       Preparing files for transfer
-----> Busser installation detected (busser)
       Installing Busser plugins: busser-bats
       Plugin bats already installed
       Removing /tmp/verifier/suites/bats
       Transferring files to <default-centos-72>
-----> Running bats test suite
       [1G   Checking for docker executable[K[77G1/1[2G[1G ✓ Checking for docker executable[K
       [0m
       1 test, 0 failures
       Finished verifying <default-centos-72> (0m2.35s).
-----> Verifying <default-ubuntu-1404>...
       Preparing files for transfer
-----> Busser installation detected (busser)
       Installing Busser plugins: busser-bats
       Plugin bats already installed
       Removing /tmp/verifier/suites/bats
       Transferring files to <default-ubuntu-1404>
-----> Running bats test suite
       [1G   Checking for docker executable[K[77G1/1[2G[1G ✓ Checking for docker executable[K
       [0m
       1 test, 0 failures
       Finished verifying <default-ubuntu-1404> (0m3.14s).
-----> Kitchen is finished. (0m5.54s)
```
