### PR TITLE
Vagrantfile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,9 @@ docker_yum_repo_gpg: 'https://yum.dockerproject.org/gpg'
 
 docker_apt_repo: "deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
 
-docker_create_group: False
+docker_create_group: True    # Optional
 docker_group_id: 797
+docker_add_current_user: True
 
 docker_tls_enable: False
 docker_tls_bind: '0.0.0.0'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -7,7 +7,12 @@
 - name: Ensure APT transport HTTPS is installed | Debian / Ubuntu
   apt:
     name: 'apt-transport-https'
-    state: installed
+    state: present
+
+- name: Ensure ca-certificates are up to date
+  apt:
+    name: "ca-certificates"
+    state: present
 
 - name: Import Docker GPG key | Debian / Ubuntu
   apt_key:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -29,3 +29,7 @@
   apt:
     name: 'docker-engine'
     state: present
+
+- name: "add user {{ ansible_user }} to docker group"
+  user: name={{ ansible_user }} groups=docker,{{ ansible_user }} append=yes
+  when: (docker_create_group == True and docker_add_current_user == True)

--- a/test/integration/default/Vagrantfile
+++ b/test/integration/default/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/test/integration/default/Vagrantfile
+++ b/test/integration/default/Vagrantfile
@@ -1,71 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "ubuntu/trusty64"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  config.vm.synced_folder "../../../../ansible-role-docker", "/home/vagrant/ansible-role-docker"
+  config.vm.provision "shell", privileged: false, path: "install-ansible.sh"
 end

--- a/test/integration/default/Vagrantfile
+++ b/test/integration/default/Vagrantfile
@@ -4,5 +4,5 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder "../../../../ansible-role-docker", "/home/vagrant/ansible-role-docker"
-  config.vm.provision "shell", privileged: false, path: "install-ansible.sh"
+  config.vm.provision "shell", privileged: false, path: "run-ansible.sh"
 end

--- a/test/integration/default/ansible.cfg
+++ b/test/integration/default/ansible.cfg
@@ -1,0 +1,16 @@
+
+[defaults]
+
+inventory = ./hosts
+host_key_checking = False
+retry_files_enabled = False
+roles_path = /home/vagrant
+nocows=1
+
+
+[privilege_escalation]
+
+#become=True
+#become_method=sudo
+#become_user=root
+#become_ask_pass=False

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+  become: yes
+  become_method: sudo
+  vars:
+    docker_create_group: True
+    #ansible_user: vagrant
   roles:
     - ansible-role-docker

--- a/test/integration/default/hosts
+++ b/test/integration/default/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost              ansible_connection=local        ansible_user=vagrant

--- a/test/integration/default/install-ansible.sh
+++ b/test/integration/default/install-ansible.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e # exit on error
+set -x
+
+if ! command -v ansible >/dev/null; then
+
+  echo "Installing Ansible dependencies and Git."
+  sudo apt-get update
+  sudo apt-get install -y software-properties-common
+  sudo apt-add-repository ppa:ansible/ansible -y
+  sudo apt-get update
+  sudo apt-get install -y ansible
+  if ! command -v ansible >/dev/null; then
+    exit 1
+  fi
+fi
+

--- a/test/integration/default/run-ansible.sh
+++ b/test/integration/default/run-ansible.sh
@@ -1,5 +1,10 @@
 set -x
 set -e # fail on error
+
+# install ansible first
 cd /vagrant
-bash install-ansible.sh # install ansible first
-ansible-playbook /vagrant/install-ansible.sh
+bash install-ansible.sh 
+
+# Run test playbook
+cd /home/vagrant/ansible-role-docker/test/integration/default/
+ansible-playbook default.yml

--- a/test/integration/default/run-ansible.sh
+++ b/test/integration/default/run-ansible.sh
@@ -1,0 +1,5 @@
+set -x
+set -e # fail on error
+cd /vagrant
+bash install-ansible.sh # install ansible first
+ansible-playbook /vagrant/install-ansible.sh


### PR DESCRIPTION
Added Vagrantfile for doing a `vagrant up` from within the `ansible-role-docker/test/integration/default` folder with an Ubuntu (or Debian) VM.
- Added a default hosts file for `localhost` provisioning inside VM
- Added ansible.cfg file which basically points to the hosts file
- Added `sudo` to the default playbook (because we test with ubuntu in this pull request)
