### PR TITLE
Fix missing Jinja expressions in TLS configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,9 +19,9 @@
     mode: '{{ item.mode }}'
   no_log: True
   with_items:
-    - { content: 'docker_tls_keys.ca_cert|default("")', dest: '{{ docker_tls_basepath }}/ca.crt', mode: '0644' }
-    - { content: 'docker_tls_keys.server_cert|default("")', dest: '{{ docker_tls_basepath }}/server.crt', mode: '0644' }
-    - { content: 'docker_tls_keys.server_key|default("")', dest: '{{ docker_tls_basepath }}/server.key', mode: '0600' }
+    - { content: '{{ docker_tls_keys.ca_cert|default("") }}', dest: '{{ docker_tls_basepath }}/ca.crt', mode: '0644' }
+    - { content: '{{ docker_tls_keys.server_cert|default("") }}', dest: '{{ docker_tls_basepath }}/server.crt', mode: '0644' }
+    - { content: '{{ docker_tls_keys.server_key|default("") }}', dest: '{{ docker_tls_basepath }}/server.key', mode: '0600' }
   when: docker_tls_enable == True and docker_tls_keys.ca_cert is defined
   notify:
     - Restart Docker


### PR DESCRIPTION
Otherwise, the literal string defined in the field `content` will be
written into the files.
